### PR TITLE
Remove cd to home

### DIFF
--- a/pacmn.sh
+++ b/pacmn.sh
@@ -65,10 +65,10 @@ echo "###############################"
 echo ""
 wget "https://github.com/PACCommunity/PAC/releases/download/v0.12.2.3/PAC-v0.12.2.3-ubuntu-16.04-x64.tar.gz"
 tar xvf 'PAC-v0.12.2.3-ubuntu-16.04-x64.tar.gz'
-cp PAC-v0.12.2.3-ubuntu-16.04-x64/* ~/
-cd ~/
+#cp PAC-v0.12.2.3-ubuntu-16.04-x64/* ~/
+#cd ~/
 rm PAC-v0.12.2.3-ubuntu-16.04-x64.tar.gz
-rm -r PAC-v0.12.2.3-ubuntu-16.04-x64
+#rm -r PAC-v0.12.2.3-ubuntu-16.04-x64
 currpath=$( pwd )
 echo "Binaries got stored on: $currpath"
 chmod +x paccoind


### PR DESCRIPTION
Following up the fix on the setup script because of removing the folder in the compressed tars.
It was left behind a `cd ~/` that can cause issues.
If the script is initiated on a folder not in ~ the script won't work.
