### PR TITLE
update locale to force en utf8

### DIFF
--- a/pac-update.sh
+++ b/pac-update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export LC_ALL=C
+export LC_ALL="en_US.UTF-8"
 set -e
 version="0.12.5.0"
 


### PR DESCRIPTION
some locale settings are going to finicky for the pip installer, default collation will fail in some edge cases. This will force english utf 8 which will make the pip installer happy :-)