### PR TITLE
Add pause

### DIFF
--- a/pac-update.sh
+++ b/pac-update.sh
@@ -202,6 +202,7 @@ install_and_run_systemd_service()
 	echo
 	systemctl status -n 0 --no-pager $PAC_SERVICE_NAME
 	echo
+	sleep 5
 	paccoin-cli getinfo
 	rm $PAC_SERVICE_NAME
 	echo 


### PR DESCRIPTION
added pause to allow the paccoind process to start before issuing getinfo cli command, some users are reporting that they get the error message that its still starting up verifying blocks. This is a safe change with no after effects.