### PR TITLE
Bump MIN PROTOCOL and added new checkpoint

### DIFF
--- a/pac-update.sh
+++ b/pac-update.sh
@@ -2,7 +2,7 @@
 
 export LC_ALL=en_US.UTF-8
 set -e
-version="0.12.5.1"
+version="0.12.6.0"
 
 echo 
 echo "################################################"

--- a/pacmn.sh
+++ b/pacmn.sh
@@ -15,8 +15,8 @@ else
 fi
 
 arch=`uname -m`
-version="0.12.5.1"
-old_version="0.12.5.0"
+version="0.12.6.0"
+old_version="0.12.5.1"
 base_url="https://github.com/PACCommunity/PAC/releases/download/v${version}"
 if [ "${arch}" == "x86_64" ]; then
 	tarball_name="PAC-v${version}-linux-x86_64.tar.gz"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -165,10 +165,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DIP0001].nThreshold = 3226; // 80% of 4032
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000291362006875385877"); // #151380
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000002ca70cb14917f702ff"); // #216000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x00000000000027377aa412aad9342c61c20973ac1636663b2ef06b3f7549876d"); // #151380
+        consensus.defaultAssumeValid = uint256S("0x00000000000038a52e7bafb7fb091ed2989ec8bdd7a550db9925300687805d87"); // #216000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -230,9 +230,10 @@ public:
             (  43850,   uint256S("0x0000000000000be675f137fbf5cbe5e9d8cb0ea509d30252a02c30944f16970f"))
             (  50000,   uint256S("0x00000000000007cdd43a784898eb9cb5be63ca7db5e5935a05a1baa01a658ca0"))
             (  50620,   uint256S("0x0000000000000349685ff23a2344db4d51ae9f169cda23c8a472fb783914b071"))
-            (  151380,  uint256S("0x00000000000027377aa412aad9342c61c20973ac1636663b2ef06b3f7549876d")),
-            1540326989, // * UNIX timestamp of last checkpoint block
-            704761,    // * total number of transactions between genesis and last checkpoint
+            (  151380,  uint256S("0x00000000000027377aa412aad9342c61c20973ac1636663b2ef06b3f7549876d"))
+            (  216000,  uint256S("0x00000000000038a52e7bafb7fb091ed2989ec8bdd7a550db9925300687805d87")),
+            1550525942, // * UNIX timestamp of last checkpoint block
+            814704,    // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
             5000        // * estimated number of transactions per day after checkpoint
         };

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -24,7 +24,7 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70206;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70214;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70215;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlocks;

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70214;
+static const int MIN_PEER_PROTO_VERSION = 70215;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
- Min protocol version is now 70215
- Bumped the version on the masternode update scripts.
- Added a checkpoint, block `#216000`.